### PR TITLE
Removed unwanted dbs from dropdown

### DIFF
--- a/models/init.rb
+++ b/models/init.rb
@@ -8,4 +8,14 @@ DB = Sequel.connect(
           :database => Config['db']['name']
       )
 
-ListDBs = DB['SHOW DATABASES']
+listdbs = DB['SHOW DATABASES']
+notWantedDbs = ['information_schema', 'mysql']
+wantedDbs = []
+
+listdbs.each do |db|
+    unless notWantedDbs.include?db[:Database]
+        wantedDbs.push db
+    end
+end
+
+ListDBs = wantedDbs


### PR DESCRIPTION
Fixes #2.

Removes `information_schema` and `mysql` from dropdown.
