### PR TITLE
Add the 1_000_000 limit like we do for CSV exports

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -89,7 +89,7 @@ class Application < Sinatra::Base
       status(404) && return
     end
 
-    results = query.results(params)
+    results = query.results(params, 1_000_000)
 
     if results[:success]
       status 200


### PR DESCRIPTION
I'm using the Asq api in Learning Trends (Edutrends) and would like to use 1 call instead of looping through 11 calls to fetch all the data i need.
