### PR TITLE
Update Dockerfile to ruby 2.3.3 alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Logs and databases #
+######################
+*.log
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# SASS Cache
+.sass-cache/
+tmp/
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+
+.ruby-version
+docker-compose.yml
+
+.Gemfile.EXAMPLE
+Rakefile.EXAMPLE
+install_*.sql
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.0-alpine
+FROM ruby:2.3.3-alpine
 
 # Environment variables:
 ENV RACK_ENV ''

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -4,11 +4,5 @@
    {
      "ContainerPort": "3000"
    }
-  ],
-  "Volumes": [
-    {
-      "HostDirectory": "/var/app",
-      "ContainerDirectory": "/var/app"
-    }
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,22 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'net-ssh'
 gem 'shotgun'
 gem 'sequel'
+gem 'bacon'
 gem 'sinatra-sequel'
 gem 'omniauth-google-oauth2'
 gem 'rake'
 
-group :production do
-  gem 'unicorn'
-end
-
 # Frontend
 gem 'haml'
 gem 'sass'
-gem 'json'
 gem 'thin'
 gem 'htmlentities'
 
 # DB, uncomment which one you want.
 # Also add config to the `config.yml` for the specified adapter.
-gem 'mysql2'
+# gem 'mysql2'
 gem 'pg'
-gem 'sqlite3'
+# gem 'sqlite3'

--- a/Gemfile.EXAMPLE
+++ b/Gemfile.EXAMPLE
@@ -1,17 +1,17 @@
 source 'http://rubygems.org'
 
-gem 'thin'
 gem 'sinatra'
 gem 'net-ssh'
 gem 'shotgun'
 gem 'sequel'
 gem 'sinatra-sequel'
-
+gem 'omniauth-google-oauth2'
+gem 'rake'
 
 # Frontend
 gem 'haml'
 gem 'sass'
-gem 'json'
+gem 'thin'
 gem 'htmlentities'
 
 # DB, uncomment which one you want.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,29 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bacon (1.2.0)
-    daemons (1.2.3)
-    eventmachine (1.2.0.1)
-    faraday (0.9.2)
+    daemons (1.2.4)
+    eventmachine (1.2.3)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     haml (4.0.7)
       tilt
-    hashie (3.4.4)
+    hashie (3.5.5)
     htmlentities (4.3.4)
-    json (1.8.3)
-    jwt (1.5.4)
-    kgio (2.10.0)
+    jwt (1.5.6)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.4)
-    net-ssh (3.1.1)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
+    net-ssh (4.1.0)
+    oauth2 (1.3.1)
+      faraday (>= 0.8, < 0.12)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+      rack (>= 1.2, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
     omniauth-google-oauth2 (0.4.1)
       jwt (~> 1.5.2)
       multi_json (~> 1.3)
@@ -35,42 +32,35 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    pg (0.18.4)
-    rack (1.6.4)
+    pg (0.20.0)
+    rack (1.6.5)
     rack-protection (1.5.3)
       rack
-    raindrops (0.16.0)
-    rake (11.1.2)
-    sass (3.4.22)
-    sequel (4.35.0)
-    shotgun (0.9.1)
+    rake (12.0.0)
+    sass (3.4.23)
+    sequel (4.44.0)
+    shotgun (0.9.2)
       rack (>= 1.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sinatra-sequel (0.9.0)
-      bacon
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
-    sqlite3 (1.3.11)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    tilt (2.0.5)
-    unicorn (5.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
+    tilt (2.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bacon
   haml
   htmlentities
-  json
-  mysql2
   net-ssh
   omniauth-google-oauth2
   pg
@@ -80,9 +70,7 @@ DEPENDENCIES
   shotgun
   sinatra
   sinatra-sequel
-  sqlite3
   thin
-  unicorn
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/docker_runner.rb
+++ b/docker_runner.rb
@@ -9,7 +9,7 @@ def get_env_or_fail(name)
   end
 end
 
-File.open("/home/asq/config.yml", "w") do |config|
+File.open("/app/config.yml", "w") do |config|
   config.puts "database:"
   config.puts "  adapter: #{get_env_or_fail("DB_ADAPTER")}"
   config.puts "  host: #{get_env_or_fail("DB_HOSTNAME")}"
@@ -32,5 +32,5 @@ File.open("/home/asq/config.yml", "w") do |config|
   config.puts "  dblistMatch: #{get_env_or_fail("MISC_DBLISTMATCH")}"
 end
 
-Dir.chdir("/home/asq")
+Dir.chdir("/app")
 exec("/usr/bin/env bundle exec thin start -p 3000")


### PR DESCRIPTION
This pull request updates the Docker image to make use of `ruby:2.3.3-alpine`.  The gems have also been updated to prevent as many deprecation errors as possible. It seems like only thin and haml still need a release to resolve deprecation warnings. Tested locally and in production environment and all seems well.