### PR TITLE
Force SSL for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'sass'
 gem 'thin'
 gem 'htmlentities'
 
+gem 'rack-ssl'
+
 # DB, uncomment which one you want.
 # Also add config to the `config.yml` for the specified adapter.
 # gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
+    rack-ssl (1.4.1)
+      rack
     rake (12.0.0)
     sass (3.4.23)
     sequel (4.44.0)
@@ -64,6 +66,7 @@ DEPENDENCIES
   net-ssh
   omniauth-google-oauth2
   pg
+  rack-ssl
   rake
   sass
   sequel


### PR DESCRIPTION
Currently ASQ allows non https connections for production. This PR makes sure it only allows HTTPS requests by default.