### PR TITLE
Update sinatra, rack and rack-protection to 2.0.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.2)
     oauth2 (1.3.1)
       faraday (>= 0.8, < 0.12)
       jwt (~> 1.0)
@@ -30,21 +31,22 @@ GEM
       omniauth (~> 1.2)
     pg (0.20.0)
     puma (3.8.2)
-    rack (1.6.9)
-    rack-protection (1.5.5)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
     rack-ssl (1.4.1)
       rack
     sass (3.4.23)
     sequel (4.44.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
     sinatra-sequel (0.9.0)
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
-    tilt (2.0.6)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Missed this one in #53 , the [advised version](https://nvd.nist.gov/vuln/detail/CVE-2018-1000119) of rack-protection is actually 2.0.0.