### PR TITLE
Ruby 2.6 and gem updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.5-alpine
+FROM ruby:2.6-alpine
 
 # Environment variables:
 ENV RACK_ENV ''
@@ -16,11 +16,11 @@ ENV READ_DATABASES ''
 ENV MISC_DEFAULT false
 ENV MISC_DBLISTMATCH false
 
-RUN apk update && apk --update add postgresql-client libstdc++
+RUN apk --update add postgresql-client libstdc++
 
 # Rubygems and bundler
-RUN gem update --system --no-ri --no-rdoc
-RUN gem install bundler --no-ri --no-rdoc
+RUN gem update --system --no-document
+RUN gem install bundler --no-document
 
 RUN mkdir /app
 
@@ -30,9 +30,10 @@ ADD Gemfile.lock /app/
 WORKDIR /app
 
 RUN apk --update add --virtual build-dependencies g++ musl-dev make \
-	postgresql-dev && \
-	bundle install --deployment && \
-	apk del build-dependencies
+  postgresql-dev && \
+  bundle config set deployment 'true' && \
+  bundle install && \
+  apk del build-dependencies
 
 ADD . /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rack-ssl'
 
 # Frontend
 gem 'haml'
-gem 'sass'
+gem 'sassc'
 gem 'htmlentities'
 
 # DB, uncomment which one you want.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (0.15.4)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
-    haml (5.0.4)
+    ffi (1.12.2)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     hashie (3.6.0)
     htmlentities (4.3.4)
-    jwt (2.1.0)
-    multi_json (1.13.1)
+    jwt (2.2.1)
+    multi_json (1.14.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
-    mustermann (1.0.3)
-    oauth2 (1.4.1)
-      faraday (>= 0.8, < 0.16.0)
+    multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.2)
+    oauth2 (1.4.3)
+      faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -23,39 +25,35 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth-google-oauth2 (0.6.0)
+    omniauth-google-oauth2 (0.8.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.5)
+      omniauth-oauth2 (>= 1.6)
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
-    pg (1.1.4)
-    puma (3.12.0)
-    rack (2.0.6)
-    rack-protection (2.0.5)
+    pg (1.2.2)
+    puma (4.3.1)
+      nio4r (~> 2.0)
+    rack (2.2.2)
+    rack-protection (2.0.8.1)
       rack
     rack-ssl (1.4.1)
       rack
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
-    sass (3.7.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sequel (5.18.0)
-    sinatra (2.0.5)
+    ruby2_keywords (0.0.2)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sequel (5.29.0)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     sinatra-sequel (0.9.0)
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
-    temple (0.8.1)
-    tilt (2.0.9)
+    temple (0.8.2)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby
@@ -67,10 +65,10 @@ DEPENDENCIES
   pg
   puma
   rack-ssl
-  sass
+  sassc
   sequel
   sinatra
   sinatra-sequel
 
 BUNDLED WITH
-   1.17.1
+   2.0.1


### PR DESCRIPTION
I noticed ASQ still runs on Ruby 2.3, so I put some time in updating it to 2.6. 

Also updated all gems to mitigate the CVEs in `rack` and `puma`.

I've also replaced `sass` with `sassc`, since `sass` has been deprecated/unmaintained for a while now.